### PR TITLE
added explicit goal to copy plugin.xml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Goal to copy plugin.xml and force recompile if necessary
+
 ## 1.0.0-rc6 - 2020-04-14
 ### Added
 - Goal to write release descriptor

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,12 @@
 
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
+      <artifactId>maven-filtering</artifactId>
+      <version>3.1.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-dependency-tree</artifactId>
       <version>2.1</version>
     </dependency>

--- a/src/main/java/sonia/scm/maven/CopyPluginXmlMojo.java
+++ b/src/main/java/sonia/scm/maven/CopyPluginXmlMojo.java
@@ -58,7 +58,7 @@ public class CopyPluginXmlMojo extends AbstractMojo {
         clean();
         copy();
       } else {
-        getLog().info("skip copy of plugin.xml, because target is newer than");
+        getLog().info("skip copy of plugin.xml, because target is newer");
       }
     } else {
       getLog().info("copy plugin.xml, because target does not exist");

--- a/src/main/java/sonia/scm/maven/CopyPluginXmlMojo.java
+++ b/src/main/java/sonia/scm/maven/CopyPluginXmlMojo.java
@@ -1,0 +1,100 @@
+package sonia.scm.maven;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Setter;
+import org.apache.commons.io.FileUtils;
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugins.annotations.Component;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.filtering.MavenFileFilter;
+import org.apache.maven.shared.filtering.MavenFilteringException;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * Copies plugin.xml only if necessary and forces recompile if plugin.xml has changed.
+ */
+@Setter(AccessLevel.PACKAGE) // for testing purposes
+@Mojo(name = "copy-plugin-xml", defaultPhase = LifecyclePhase.PROCESS_RESOURCES)
+public class CopyPluginXmlMojo extends AbstractMojo {
+
+  @Getter(AccessLevel.PACKAGE)
+  @Parameter(defaultValue = "src/main/resources/META-INF/scm/plugin.xml", required = true)
+  private File source;
+
+  @Getter(AccessLevel.PACKAGE)
+  @Parameter(defaultValue = "${project.build.outputDirectory}", required = true)
+  private File outputDirectory;
+
+  @Getter(AccessLevel.PACKAGE)
+  @Parameter(defaultValue = "${project.build.outputDirectory}/META-INF/scm/plugin.xml", required = true)
+  private File target;
+
+  @Parameter(defaultValue = "${project}", readonly = true, required = true)
+  private MavenProject project;
+
+  @Parameter(defaultValue = "${session}", readonly = true, required = true)
+  private MavenSession session;
+
+  @Parameter(defaultValue = "${project.build.filters}", readonly = true)
+  private List<String> buildFilters;
+
+  @Component(role = MavenFileFilter.class, hint = "default")
+  private MavenFileFilter fileFilter;
+
+  @Override
+  public void execute() throws MojoExecutionException {
+    if (target.exists()) {
+      if (isSourceModified()) {
+        getLog().info("source plugin.xml is newer than target, force complete rebuild");
+        clean();
+        copy();
+      } else {
+        getLog().info("skip copy of plugin.xml, because target is newer than");
+      }
+    } else {
+      getLog().info("copy plugin.xml, because target does not exist");
+      copy();
+    }
+  }
+
+  private boolean isSourceModified() {
+    return source.lastModified() > target.lastModified();
+  }
+
+  private void clean() throws MojoExecutionException {
+    try {
+      FileUtils.deleteDirectory(outputDirectory);
+    } catch (IOException e) {
+      throw new MojoExecutionException("failed to remove output directory " + outputDirectory, e);
+    }
+  }
+
+  private void copy() throws MojoExecutionException {
+    File parent = target.getParentFile();
+    if (!parent.exists() && !parent.mkdirs()) {
+      throw new MojoExecutionException("failed to create plugin.xml parent directory: " + parent);
+    }
+    try {
+      fileFilter.copyFile(
+        source,
+        target,
+        true,
+        project,
+        buildFilters,
+        true,
+        "UTF-8",
+        session);
+    } catch (MavenFilteringException e) {
+      throw new MojoExecutionException(e.getMessage(), e);
+    }
+  }
+}

--- a/src/main/resources/META-INF/plexus/components.xml
+++ b/src/main/resources/META-INF/plexus/components.xml
@@ -40,6 +40,7 @@ https://bitbucket.org/sdorra/smp-maven-plugin
       <configuration>
         <phases>
           <process-resources>
+            sonia.scm.maven:smp-maven-plugin:copy-plugin-xml,
             org.apache.maven.plugins:maven-resources-plugin:resources,
             sonia.scm.maven:smp-maven-plugin:fix-descriptor,
             sonia.scm.maven:smp-maven-plugin:append-dependencies,
@@ -92,6 +93,7 @@ https://bitbucket.org/sdorra/smp-maven-plugin
         </phases>
         <default-phases>
           <smp-process-resources>
+            sonia.scm.maven:smp-maven-plugin:copy-plugin-xml,
             org.apache.maven.plugins:maven-resources-plugin:resources,
             sonia.scm.maven:smp-maven-plugin:fix-descriptor,
             sonia.scm.maven:smp-maven-plugin:append-dependencies,

--- a/src/test/java/sonia/scm/maven/CopyPluginXmlMojoTest.java
+++ b/src/test/java/sonia/scm/maven/CopyPluginXmlMojoTest.java
@@ -1,0 +1,109 @@
+package sonia.scm.maven;
+
+import org.apache.maven.execution.MavenSession;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.apache.maven.shared.filtering.MavenFileFilter;
+import org.apache.maven.shared.filtering.MavenFilteringException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junitpioneer.jupiter.TempDirectory;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+@SuppressWarnings("ResultOfMethodCallIgnored")
+@ExtendWith({MockitoExtension.class, TempDirectory.class})
+class CopyPluginXmlMojoTest {
+
+  @Mock
+  private MavenProject project;
+
+  @Mock
+  private MavenSession session;
+
+  @Mock
+  private MavenFileFilter fileFilter;
+
+  private final List<String> filters = Collections.emptyList();
+
+  @Test
+  void shouldCopyPluginXml(@TempDirectory.TempDir Path tempPath) throws IOException, MojoExecutionException, MavenFilteringException {
+    CopyPluginXmlMojo mojo = createMojo(tempPath);
+    mojo.getSource().createNewFile();
+    mojo.execute();
+
+    assertThat(mojo.getOutputDirectory()).exists();
+    assertCopied(mojo);
+  }
+
+  @Test
+  void shouldNotCopyPluginXml(@TempDirectory.TempDir Path tempPath) throws IOException, MojoExecutionException {
+    CopyPluginXmlMojo mojo = createMojo(tempPath);
+    mojo.getOutputDirectory().mkdirs();
+    mojo.getTarget().createNewFile();
+    mojo.getSource().createNewFile();
+
+    mojo.execute();
+    verifyZeroInteractions(fileFilter);
+  }
+
+  @Test
+  void shouldCopyPluginXmlAndDeleteOutputDirectory(@TempDirectory.TempDir Path tempPath) throws IOException, MojoExecutionException, MavenFilteringException {
+    CopyPluginXmlMojo mojo = createMojo(tempPath);
+
+    File outputDirectory = mojo.getOutputDirectory();
+    outputDirectory.mkdirs();
+
+    File other = new File(outputDirectory, "other");
+    other.createNewFile();
+
+    File target = mojo.getTarget();
+    target.createNewFile();
+    target.setLastModified(42L);
+
+    mojo.getSource().createNewFile();
+
+    mojo.execute();
+
+    assertThat(outputDirectory).exists();
+    assertThat(other).doesNotExist();
+    assertCopied(mojo);
+  }
+
+  private void assertCopied(CopyPluginXmlMojo mojo) throws MavenFilteringException {
+    verify(fileFilter).copyFile(mojo.getSource(), mojo.getTarget(), true, project, filters, true, "UTF-8", session);
+  }
+
+  private CopyPluginXmlMojo createMojo(Path tempPath) {
+    CopyPluginXmlMojo mojo = new CopyPluginXmlMojo();
+    mojo.setBuildFilters(Collections.emptyList());
+    mojo.setFileFilter(fileFilter);
+
+    File tempDir = tempPath.toFile();
+
+    File outputDirectory = new File(tempDir, "out");
+    mojo.setOutputDirectory(outputDirectory);
+
+    File target = new File(outputDirectory, "plugin.xml");
+    mojo.setTarget(target);
+
+    File source = new File(tempDir, "plugin.xml");
+    mojo.setSource(source);
+
+    mojo.setProject(project);
+    mojo.setSession(session);
+
+    return mojo;
+  }
+
+}


### PR DESCRIPTION
The copy-plugin-xml goal will copy the plugin.xml only if it not already exists or if the source is newer than the target.
The goal will also force a recompile, by deleting the output directory, if the plugin.xml was overwritten.