### PR TITLE
Add rule to validate min core version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Added
+- Validation rule for min core version ([#8](https://github.com/scm-manager/smp-maven-plugin/pull/8))
 ### Changed
 - Throw error on mismatching versions instead of warning ([#7](https://github.com/scm-manager/smp-maven-plugin/pull/7))
 

--- a/pom.xml
+++ b/pom.xml
@@ -434,7 +434,7 @@
     <jaxb.version>2.3.0</jaxb.version>
     <jetty.version>9.4.26.v20200117</jetty.version>
 
-    <junit.jupiter.version>5.3.0</junit.jupiter.version>
+    <junit.jupiter.version>5.6.2</junit.jupiter.version>
     <mockito.version>2.21.0</mockito.version>
   </properties>
 </project>

--- a/src/main/java/sonia/scm/maven/AppendDependenciesMojo.java
+++ b/src/main/java/sonia/scm/maven/AppendDependenciesMojo.java
@@ -118,16 +118,16 @@ public class AppendDependenciesMojo extends AbstractDescriptorMojo
     Element optionalDependenciesEl = doc.createElement(ELEMENT_OPTIONAL_DEPENDENCIES);
     root.appendChild(optionalDependenciesEl);
 
-    dependencies.forEach(smp -> {
+    for (SmpArtifact smp : dependencies) {
       Element dependencyEl = doc.createElement(ELEMENT_DEPENDENCY);
-      dependencyEl.setTextContent(smp.getPluginName());
+      dependencyEl.setTextContent(smp.getDescriptor().findName());
       dependencyEl.setAttribute(ATTRIBUTE_VERSION, smp.getVersion());
       if (smp.isOptional()) {
         optionalDependenciesEl.appendChild(dependencyEl);
       } else {
         dependenciesEl.appendChild(dependencyEl);
       }
-    });
+    }
 
     XmlNodes.writeDocument(descriptor, doc);
   }

--- a/src/main/java/sonia/scm/maven/PluginDescriptor.java
+++ b/src/main/java/sonia/scm/maven/PluginDescriptor.java
@@ -1,0 +1,57 @@
+package sonia.scm.maven;
+
+import com.google.common.base.Strings;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+
+import java.io.File;
+import java.util.Optional;
+
+public class PluginDescriptor {
+
+  private static final String ELEMENT_NAME = "name";
+  private static final String ELEMENT_INFORMATION = "information";
+  private static final String ELEMENT_CONDITIONS = "conditions";
+  private static final String ELEMENT_MIN_VERSION = "min-version";
+
+  private final Document document;
+
+  private PluginDescriptor(Document document) {
+    this.document = document;
+  }
+
+  public static PluginDescriptor from(File file) throws MojoExecutionException {
+    return new PluginDescriptor(XmlNodes.createDocument(file));
+  }
+
+  public static PluginDescriptor from(byte[] bytes) throws MojoExecutionException {
+    return new PluginDescriptor(XmlNodes.createDocument(bytes));
+  }
+
+  public static PluginDescriptor from(Document document) {
+    return new PluginDescriptor(document);
+  }
+
+  public String findName() throws MojoExecutionException {
+    Node information = XmlNodes.getChild(document.getDocumentElement(), ELEMENT_INFORMATION);
+    if (information != null) {
+      Node name = XmlNodes.getChild(information, ELEMENT_NAME);
+      if (name != null) {
+        return name.getTextContent();
+      }
+    }
+    throw new MojoExecutionException("found plugin descriptor without name");
+  }
+
+  public Optional<String> findMinVersion() {
+    Node conditions = XmlNodes.getChild(document.getDocumentElement(), ELEMENT_CONDITIONS);
+    if (conditions != null) {
+      Node minVersion = XmlNodes.getChild(conditions, ELEMENT_MIN_VERSION);
+      if (minVersion != null && !Strings.isNullOrEmpty(minVersion.getTextContent())) {
+        return Optional.of(minVersion.getTextContent());
+      }
+    }
+    return Optional.empty();
+  }
+}

--- a/src/main/java/sonia/scm/maven/SmpArtifact.java
+++ b/src/main/java/sonia/scm/maven/SmpArtifact.java
@@ -46,11 +46,11 @@ public class SmpArtifact implements ArtifactItem {
 
   public static final String TYPE = "smp";
 
-  private String pluginName;
   private String groupId;
   private String artifactId;
   private String version;
   private boolean optional;
+  private PluginDescriptor descriptor;
 
   @Override
   public String getType() {

--- a/src/main/java/sonia/scm/maven/XmlNodes.java
+++ b/src/main/java/sonia/scm/maven/XmlNodes.java
@@ -20,27 +20,27 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 
-class XmlNodes {
+public class XmlNodes {
 
   private XmlNodes() {
   }
 
-  static boolean hasChild(Node parent, String name) {
+  public static boolean hasChild(Node parent, String name) {
     return getChild(parent, name) != null;
   }
 
-  static Node getChild(Document document, String name) {
+  public static Node getChild(Document document, String name) {
     return getChild(document.getDocumentElement(), name);
   }
 
-  static void removeNode(Node parent, String name) {
+  public static void removeNode(Node parent, String name) {
     Node child = getChild(parent, name);
     if (child != null) {
       parent.removeChild(child);
     }
   }
 
-  static Node getChild(Node parent, String name) {
+  public static Node getChild(Node parent, String name) {
     NodeList children = parent.getChildNodes();
     for (int i = 0; i < children.getLength(); i++) {
       Node child = children.item(i);
@@ -52,13 +52,13 @@ class XmlNodes {
     return null;
   }
 
-  static void appendIfNotExists(Document document, Node informationNode, String name, String artifactId) {
+  public static void appendIfNotExists(Document document, Node informationNode, String name, String artifactId) {
     if (!hasChild(informationNode, name)) {
       appendNode(document, informationNode, name, artifactId);
     }
   }
 
-  static void writeDocument(File descriptor, Document document)
+  public static void writeDocument(File descriptor, Document document)
     throws MojoExecutionException {
     try {
       Transformer transformer = TransformerFactory.newInstance().newTransformer();
@@ -71,7 +71,7 @@ class XmlNodes {
     }
   }
 
-  static void appendNode(Document document, Node parent, String name, String value) {
+  public static void appendNode(Document document, Node parent, String name, String value) {
     if (value != null) {
       Element node = document.createElement(name);
 
@@ -80,7 +80,7 @@ class XmlNodes {
     }
   }
 
-  static Document createDocument(byte[] bytes) throws MojoExecutionException {
+  public static Document createDocument(byte[] bytes) throws MojoExecutionException {
     try (ByteArrayInputStream input = new ByteArrayInputStream(bytes)) {
       return documentBuilder().parse(input);
     } catch (IOException | SAXException ex) {
@@ -88,7 +88,7 @@ class XmlNodes {
     }
   }
 
-  static Document createDocument(File descriptor) throws MojoExecutionException {
+  public static Document createDocument(File descriptor) throws MojoExecutionException {
     try {
       return documentBuilder().parse(descriptor);
     } catch (IOException | SAXException ex) {

--- a/src/main/java/sonia/scm/maven/doctor/FixMojo.java
+++ b/src/main/java/sonia/scm/maven/doctor/FixMojo.java
@@ -3,12 +3,13 @@ package sonia.scm.maven.doctor;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-@Mojo(name = "fix")
+@Mojo(name = "fix", requiresDependencyResolution = ResolutionScope.RUNTIME)
 public class FixMojo extends AbstractDoctorMojo {
 
   @Override

--- a/src/main/java/sonia/scm/maven/doctor/Rules.java
+++ b/src/main/java/sonia/scm/maven/doctor/Rules.java
@@ -1,6 +1,7 @@
 package sonia.scm.maven.doctor;
 
 import com.google.common.collect.ImmutableList;
+import sonia.scm.maven.doctor.rules.MinCoreVersionRule;
 import sonia.scm.maven.doctor.rules.MissingPostInstallRule;
 import sonia.scm.maven.doctor.rules.NameRule;
 import sonia.scm.maven.doctor.rules.UiPluginsVersionRule;
@@ -31,7 +32,8 @@ public final class Rules implements Iterable<Rule> {
       new NameRule(),
       new VersionRule(),
       new MissingPostInstallRule(),
-      new UiPluginsVersionRule()
+      new UiPluginsVersionRule(),
+      new MinCoreVersionRule()
     ));
   }
 

--- a/src/main/java/sonia/scm/maven/doctor/ValidateMojo.java
+++ b/src/main/java/sonia/scm/maven/doctor/ValidateMojo.java
@@ -3,8 +3,9 @@ package sonia.scm.maven.doctor;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.ResolutionScope;
 
-@Mojo(name = "validate", defaultPhase = LifecyclePhase.VALIDATE)
+@Mojo(name = "validate", defaultPhase = LifecyclePhase.VALIDATE, requiresDependencyResolution = ResolutionScope.RUNTIME)
 public class ValidateMojo extends AbstractDoctorMojo {
 
   @Override

--- a/src/main/java/sonia/scm/maven/doctor/rules/MinCoreVersionRule.java
+++ b/src/main/java/sonia/scm/maven/doctor/rules/MinCoreVersionRule.java
@@ -26,7 +26,7 @@ public class MinCoreVersionRule implements Rule {
   @VisibleForTesting
   static final String NO_PLUGIN = "no min version for plugin defined";
   @VisibleForTesting
-  static final String NO_DEPENDENCY = "no min version for plugin defined";
+  static final String NO_DEPENDENCY = "no plugin dependencies found";
   @VisibleForTesting
   static final String ERROR_PLUGIN = "failed to find min version of plugin";
   @VisibleForTesting

--- a/src/main/java/sonia/scm/maven/doctor/rules/MinCoreVersionRule.java
+++ b/src/main/java/sonia/scm/maven/doctor/rules/MinCoreVersionRule.java
@@ -1,0 +1,127 @@
+package sonia.scm.maven.doctor.rules;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.maven.artifact.versioning.ComparableVersion;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.project.MavenProject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import sonia.scm.maven.PluginDescriptor;
+import sonia.scm.maven.SmpArtifact;
+import sonia.scm.maven.SmpDependencyCollector;
+import sonia.scm.maven.doctor.Context;
+import sonia.scm.maven.doctor.Result;
+import sonia.scm.maven.doctor.Rule;
+
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.Optional;
+
+public class MinCoreVersionRule implements Rule {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MinCoreVersionRule.class);
+
+  @VisibleForTesting
+  static final String PLUGIN_XML_PATH = "src/main/resources/META-INF/scm/plugin.xml";
+  @VisibleForTesting
+  static final String NO_PLUGIN = "no min version for plugin defined";
+  @VisibleForTesting
+  static final String NO_DEPENDENCY = "no min version for plugin defined";
+  @VisibleForTesting
+  static final String ERROR_PLUGIN = "failed to find min version of plugin";
+  @VisibleForTesting
+  static final String ERROR_DEPENDENCY = "failed to compute min version of plugin dependencies";
+
+  private static final String PLUGIN_OLDER = "The specified min version of %s is older than %s, which is required by one of the depending plugins";
+  private static final String PLUGIN_NEWER = "Current min version %s is newer or equal than %s, which is requested by depending plugins";
+
+  private final DependencyResolver dependencyResolver;
+
+  public MinCoreVersionRule() {
+    this(SmpDependencyCollector::collect);
+  }
+
+  MinCoreVersionRule(DependencyResolver dependencyResolver) {
+    this.dependencyResolver = dependencyResolver;
+  }
+
+  @Override
+  public Result validate(Context context) {
+    MavenProject project = context.getProject();
+
+    Optional<ComparableVersion> currentMinVersion;
+    try {
+      currentMinVersion = findCurrentMinVersion(project);
+      if (!currentMinVersion.isPresent()) {
+        return Result.error(NO_PLUGIN).build();
+      }
+    } catch (MojoExecutionException e) {
+      LOG.error(ERROR_PLUGIN, e);
+      return Result.error(ERROR_PLUGIN).build();
+    }
+
+    Optional<ComparableVersion> dependencyMinVersion;
+    try {
+      dependencyMinVersion = findDependencyMinVersion(project);
+      if (!dependencyMinVersion.isPresent()) {
+        return Result.ok(NO_DEPENDENCY);
+      }
+    } catch (MojoExecutionException e) {
+      LOG.error(ERROR_DEPENDENCY, e);
+      return Result.error(ERROR_DEPENDENCY).build();
+    }
+
+    return compare(currentMinVersion.get(), dependencyMinVersion.get());
+  }
+
+  private Result compare(ComparableVersion currentMinVersion, ComparableVersion dependencyMinVersion) {
+    if (currentMinVersion.compareTo(dependencyMinVersion) < 0) {
+      String message = String.format(PLUGIN_OLDER, currentMinVersion, dependencyMinVersion);
+      return Result.error(message).build();
+    }
+    String message = String.format(PLUGIN_NEWER, currentMinVersion, dependencyMinVersion);
+    return Result.ok(message);
+  }
+
+  private Optional<ComparableVersion> findDependencyMinVersion(MavenProject project) throws MojoExecutionException {
+    return dependencyResolver.resolve(project)
+      .stream().map(smp -> smp.getDescriptor().findMinVersion())
+      .filter(Optional::isPresent)
+      .map(Optional::get)
+      .map(ComparableVersion::new)
+      .max(ComparableVersion::compareTo);
+  }
+
+  private Optional<ComparableVersion> findCurrentMinVersion(MavenProject project) throws MojoExecutionException {
+    Path basedir = project.getBasedir().toPath();
+    Path pluginXmlPath = basedir.resolve(PLUGIN_XML_PATH);
+
+    try {
+      Optional<String> optionalMinVersion = findPluginMinVersion(pluginXmlPath);
+
+      if (!optionalMinVersion.isPresent()) {
+        return Optional.empty();
+      }
+
+      String minVersion = optionalMinVersion.get();
+
+      if (minVersion.equals("${project.parent.version}")) {
+        minVersion = project.getParent().getVersion();
+      }
+
+      return Optional.of(new ComparableVersion(minVersion));
+    } catch (Exception e) {
+      throw new MojoExecutionException("failed to parse " + pluginXmlPath, e);
+    }
+  }
+
+  private Optional<String> findPluginMinVersion(Path pluginXmlPath) throws MojoExecutionException {
+    return PluginDescriptor.from(pluginXmlPath.toFile()).findMinVersion();
+  }
+
+  @FunctionalInterface
+  interface DependencyResolver {
+    Collection<SmpArtifact> resolve(MavenProject project) throws MojoExecutionException;
+  }
+
+}

--- a/src/test/java/sonia/scm/maven/doctor/rules/MinCoreVersionRuleTest.java
+++ b/src/test/java/sonia/scm/maven/doctor/rules/MinCoreVersionRuleTest.java
@@ -1,0 +1,136 @@
+package sonia.scm.maven.doctor.rules;
+
+import com.google.common.io.Resources;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.w3c.dom.Document;
+import org.w3c.dom.Node;
+import sonia.scm.maven.PluginDescriptor;
+import sonia.scm.maven.SmpArtifact;
+import sonia.scm.maven.XmlNodes;
+import sonia.scm.maven.doctor.Result;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static sonia.scm.maven.doctor.rules.MinCoreVersionRule.*;
+
+@ExtendWith(MockitoExtension.class)
+class MinCoreVersionRuleTest extends RuleTestBase {
+
+  private Path directory;
+
+  @BeforeEach
+  void setUpProject(@TempDir Path directory) {
+    this.directory = directory;
+    when(project.getBasedir()).thenReturn(directory.toFile());
+  }
+
+  @Test
+  void shouldReturnOkWithoutDependencies() throws IOException, MojoExecutionException {
+    Result result = validate("2.0.0");
+    assertResult(result, Result.Type.OK);
+  }
+
+  @Test
+  void shouldReturnOkIfPluginIsNewerThanDependency() throws IOException, MojoExecutionException {
+    Result result = validate("2.1.0", "2.0.0");
+    assertResult(result, Result.Type.OK);
+  }
+
+  @Test
+  void shouldFailIfNewerVersionIsRequired() throws IOException, MojoExecutionException {
+    Result result = validate("2.1.0", "2.0.0", "2.0.1", "2.2.0");
+    assertResult(result, Result.Type.ERROR, "2.1.0", "2.2.0");
+  }
+
+  @Test
+  void shouldResolveParentVersionExpression() throws IOException, MojoExecutionException {
+    when(project.getParent().getVersion()).thenReturn("2.2.1");
+    Result result = validate("${project.parent.version}", "2.0.1");
+    assertResult(result, Result.Type.OK, "2.0.1", "2.2.1");
+  }
+
+  @Test
+  void shouldFailIfDependencyVersionCouldNotBeResolved() throws IOException, MojoExecutionException {
+    createDescriptor("2.0.0");
+
+    MinCoreVersionRule rule = new MinCoreVersionRule(project -> {
+      throw new MojoExecutionException("failed");
+    });
+
+    Result result = rule.validate(context);
+    assertResult(result, Result.Type.ERROR, ERROR_DEPENDENCY);
+  }
+
+  @Test
+  void shouldFailWithPluginMinVersion() throws IOException, MojoExecutionException {
+    Result result = validate("");
+    assertResult(result, Result.Type.ERROR, NO_PLUGIN);
+  }
+
+  @Test
+  void shouldFailPluginVersionCouldNotBeResolved() throws IOException, MojoExecutionException {
+    MinCoreVersionRule rule = new MinCoreVersionRule(project -> Collections.emptyList());
+    Result result = rule.validate(context);
+    assertResult(result, Result.Type.ERROR, ERROR_PLUGIN);
+  }
+
+  private void assertResult(Result result, Result.Type expectedType, String... expectedMessageParts) {
+    assertThat(result.getType()).isSameAs(expectedType);
+    if (expectedMessageParts.length > 0) {
+      assertThat(result.getMessage()).contains(expectedMessageParts);
+    }
+  }
+
+  private Result validate(String pluginMinVersion, String... dependencyMinVersions) throws IOException, MojoExecutionException {
+    createDescriptor(pluginMinVersion);
+    List<SmpArtifact> smps = Arrays.stream(dependencyMinVersions)
+      .map(this::smp)
+      .collect(Collectors.toList());
+    return new MinCoreVersionRule(project -> smps).validate(context);
+  }
+
+  private SmpArtifact smp(String minVersion) {
+    PluginDescriptor descriptor = mock(PluginDescriptor.class);
+    when(descriptor.findMinVersion()).thenReturn(Optional.ofNullable(minVersion));
+    return new SmpArtifact(
+      "sonia.scm.plugins",
+      "scm-test-plugin",
+      "1.0.0",
+      false,
+      descriptor
+    );
+  }
+
+  @SuppressWarnings("UnstableApiUsage")
+  private void createDescriptor(String minVersion) throws IOException, MojoExecutionException {
+    URL resource = Resources.getResource("sonia/scm/maven/doctor/rules/scm-review-plugin.xml");
+    byte[] bytes = Resources.toByteArray(resource);
+
+    Document document = XmlNodes.createDocument(bytes);
+    Node conditionsNode = XmlNodes.getChild(document, "conditions");
+    Node minVersionNode = XmlNodes.getChild(conditionsNode, "min-version");
+    minVersionNode.setTextContent(minVersion);
+
+    Path pluginXmlPath = directory.resolve(MinCoreVersionRule.PLUGIN_XML_PATH);
+    Files.createDirectories(pluginXmlPath.getParent());
+
+    XmlNodes.writeDocument(pluginXmlPath.toFile(), document);
+  }
+
+}

--- a/src/test/resources/sonia/scm/maven/doctor/rules/scm-review-plugin.xml
+++ b/src/test/resources/sonia/scm/maven/doctor/rules/scm-review-plugin.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+
+    MIT License
+
+    Copyright (c) 2020-present Cloudogu GmbH and Contributors
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in all
+    copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+    SOFTWARE.
+
+-->
+<!DOCTYPE plugin SYSTEM "https://download.scm-manager.org/dtd/plugin/2.0.0-01.dtd">
+<plugin>
+
+  <scm-version>2</scm-version>
+
+  <information>
+    <displayName>Review</displayName>
+    <author>Cloudogu GmbH</author>
+    <category>Workflow</category>
+  </information>
+
+  <conditions>
+    <min-version>${project.parent.version}</min-version>
+  </conditions>
+
+  <resources>
+    <script>assets/scm-review-plugin.bundle.js</script>
+  </resources>
+
+</plugin>


### PR DESCRIPTION
## Proposed changes

This pr will add a new rule which validates the core min version in the plugin.xml of a plugin. The min version in the plugin.xml has to be higher or equal as the min version of the plugins.

### Your checklist for this pull request

- [X] PR is well described
- [X] Code does not conflict with target branch
- [X] New code is covered with unit tests
- [X] CHANGELOG.md updated