### PR TITLE
Add validation for plugin.json files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Added
+- Validation for plugin.json files ([#10](https://github.com/scm-manager/smp-maven-plugin/pull/10))
+
 ## 1.3.0 - 2020-10-20
 ### Added
 - Mechanism for running ui deployments

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>sonia.scm.maven</groupId>
   <artifactId>smp-maven-plugin</artifactId>
-  <version>1.3.1-SNAPSHOT</version>
+  <version>1.4.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
   <description>
     Maven packaging for SCM-Manager 2.x plugins.

--- a/src/main/java/sonia/scm/maven/doctor/Rules.java
+++ b/src/main/java/sonia/scm/maven/doctor/Rules.java
@@ -5,6 +5,7 @@ import sonia.scm.maven.doctor.rules.MinCoreVersionRule;
 import sonia.scm.maven.doctor.rules.MissingPostInstallRule;
 import sonia.scm.maven.doctor.rules.NameRule;
 import sonia.scm.maven.doctor.rules.UiPluginsVersionRule;
+import sonia.scm.maven.doctor.rules.ValidPluginsJsonRule;
 import sonia.scm.maven.doctor.rules.VersionRule;
 
 import java.util.Iterator;
@@ -33,7 +34,8 @@ public final class Rules implements Iterable<Rule> {
       new VersionRule(),
       new MissingPostInstallRule(),
       new UiPluginsVersionRule(),
-      new MinCoreVersionRule()
+      new MinCoreVersionRule(),
+      new ValidPluginsJsonRule()
     ));
   }
 

--- a/src/main/java/sonia/scm/maven/doctor/rules/ValidPluginsJsonRule.java
+++ b/src/main/java/sonia/scm/maven/doctor/rules/ValidPluginsJsonRule.java
@@ -1,0 +1,56 @@
+package sonia.scm.maven.doctor.rules;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.maven.model.FileSet;
+import sonia.scm.maven.doctor.Context;
+import sonia.scm.maven.doctor.Result;
+import sonia.scm.maven.doctor.Rule;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import static java.util.Optional.empty;
+import static java.util.Optional.of;
+
+public class ValidPluginsJsonRule implements Rule {
+  @Override
+  public Result validate(Context context) {
+    return context.getProject().getResources()
+      .stream()
+      .map(FileSet::getDirectory)
+      .map(Paths::get)
+      .filter(Files::isDirectory)
+      .map(resourcesDirectory -> resourcesDirectory.resolve("locales"))
+      .filter(Files::isDirectory)
+      .flatMap(this::listLocales)
+      .map(countryLocaleDirectory -> countryLocaleDirectory.resolve("plugins.json"))
+      .filter(Files::isRegularFile)
+      .map(this::validateJson)
+      .filter(Optional::isPresent)
+      .map(Optional::get)
+      .findFirst()
+      .orElse(Result.ok("locale resources contain valid json (if present)"));
+  }
+
+  private Stream<Path> listLocales(Path localsDirectory) {
+    try {
+      return Files.list(localsDirectory);
+    } catch (IOException e) {
+      e.printStackTrace();
+      return Stream.empty();
+    }
+  }
+
+  private Optional<Result> validateJson(Path pluginsJsonFile) {
+    try {
+      new ObjectMapper().readTree(pluginsJsonFile.toFile());
+      return empty();
+    } catch (IOException e) {
+      return of(Result.error(pluginsJsonFile + " contains invalid json: " + e.getLocalizedMessage()).build());
+    }
+  }
+}

--- a/src/test/java/sonia/scm/maven/doctor/rules/ValidPluginsJsonRuleTest.java
+++ b/src/test/java/sonia/scm/maven/doctor/rules/ValidPluginsJsonRuleTest.java
@@ -1,0 +1,90 @@
+package sonia.scm.maven.doctor.rules;
+
+import org.apache.maven.model.Resource;
+import org.apache.maven.project.MavenProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import sonia.scm.maven.doctor.Context;
+import sonia.scm.maven.doctor.Result;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static java.util.Collections.singletonList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ValidPluginsJsonRuleTest {
+
+  @Mock
+  Context context;
+  @Mock
+  MavenProject project;
+  @Mock
+  Resource resource;
+
+  @BeforeEach
+  void mockContext(@TempDir Path temp) {
+    when(context.getProject()).thenReturn(project);
+    when(project.getResources()).thenReturn(singletonList(resource));
+    when(resource.getDirectory()).thenReturn(temp.toAbsolutePath().toString());
+  }
+
+  @Test
+  void shouldFailWithCorruptJson(@TempDir Path temp) throws IOException {
+    writeJsonForLanguage(temp, "en", "{\"valid\": true}");
+    writeJsonForLanguage(temp, "de", "{invalid: true}");
+
+    Result result = new ValidPluginsJsonRule().validate(context);
+
+    assertThat(result.getType()).isEqualTo(Result.Type.ERROR);
+  }
+
+  @Test
+  void shouldSucceedWithValidJson(@TempDir Path temp) throws IOException {
+    writeJsonForLanguage(temp, "en", "{\"valid\": true}");
+    writeJsonForLanguage(temp, "de", "{\"valid\": \"too\"}");
+
+    Result result = new ValidPluginsJsonRule().validate(context);
+
+    assertThat(result.getType()).isEqualTo(Result.Type.OK);
+  }
+
+  @Test
+  void shouldHandleMissingLocalesDirectory() {
+    Result result = new ValidPluginsJsonRule().validate(context);
+
+    assertThat(result.getType()).isEqualTo(Result.Type.OK);
+  }
+
+  @Test
+  void shouldHandleMissingLanguageDirectory(@TempDir Path temp) throws IOException {
+    Files.createDirectories(temp.resolve("locales"));
+
+    Result result = new ValidPluginsJsonRule().validate(context);
+
+    assertThat(result.getType()).isEqualTo(Result.Type.OK);
+  }
+
+  @Test
+  void shouldHandleMissingPluginsJsonFile(@TempDir Path temp) throws IOException {
+    Files.createDirectories(temp.resolve("locales").resolve("de"));
+
+    Result result = new ValidPluginsJsonRule().validate(context);
+
+    assertThat(result.getType()).isEqualTo(Result.Type.OK);
+  }
+
+  private void writeJsonForLanguage(Path temp, String language, String json) throws IOException {
+    Path de = temp.resolve("locales").resolve(language);
+    Files.createDirectories(de);
+    Path pluginsJson = de.resolve("plugins.json");
+    Files.write(pluginsJson, singletonList(json));
+  }
+}


### PR DESCRIPTION
## Proposed changes

This adds a validation step (for `mvn smp:validate`) that asserts that all `plugin.json` files contain valid json content.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] PR is well described
- [x] Related issues linked to PR if existing and labels set
- [x] Target branch is in this case master (because this repo has no develop branch) 
- [x] Code does not conflict with target branch
- [x] New code is covered with unit tests
- [x] CHANGELOG.md updated
- [x] Definition of Done's fulfilled: [DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/definition-of-done.md) // [UI DoD](https://github.com/scm-manager/scm-manager/blob/develop/docs/en/development/ui-dod.md)
- [ ] Documentation updated (only necessary for new features or changed behaviour)

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
